### PR TITLE
Implemented admin account creation

### DIFF
--- a/src/main/java/com/eukon05/financetracker/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/eukon05/financetracker/configuration/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package com.eukon05.financetracker.configuration;
 
 import com.eukon05.financetracker.jwt.JwtToAuthenticationConverter;
+import com.eukon05.financetracker.user.RoleType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -38,11 +39,12 @@ class SecurityConfiguration {
 
         http.authorizeHttpRequests(auth -> {
             auth.requestMatchers(HttpMethod.POST, "/users").permitAll();
+            auth.requestMatchers(HttpMethod.POST, "/users/admin").permitAll();
             auth.requestMatchers("/users/**").authenticated();
             auth.requestMatchers("/transactions/**").authenticated();
             auth.requestMatchers("/wallets/**").authenticated();
             auth.requestMatchers(HttpMethod.GET, "/categories/**").authenticated();
-            auth.requestMatchers("/categories/**").hasAuthority("ADMIN");
+            auth.requestMatchers("/categories/**").hasAuthority(RoleType.ADMIN.name());
             auth.anyRequest().permitAll();
         });
 

--- a/src/main/java/com/eukon05/financetracker/user/UserController.java
+++ b/src/main/java/com/eukon05/financetracker/user/UserController.java
@@ -69,4 +69,17 @@ class UserController {
         userFacade.updateUserPassword(principal.getName(), dto.password(), request.getRequestURL().toString().replace("/users/me/password", ""));
     }
 
+    @PostMapping("/admin")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Register an administrator account")
+    @SecurityRequirements
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "409", ref = "conflict"),
+            @ApiResponse(responseCode = "400", ref = "validation"),
+            @ApiResponse(responseCode = "401", ref = "unauthorized")
+    })
+    void createAdmin(@RequestParam(name = "masterPassword") String masterPassword, RegisterDTO dto, HttpServletRequest request) {
+        userFacade.createAdmin(masterPassword, dto, request.getRequestURL().toString().replace("/users/admin", ""));
+    }
+
 }

--- a/src/main/java/com/eukon05/financetracker/user/UserRepository.java
+++ b/src/main/java/com/eukon05/financetracker/user/UserRepository.java
@@ -12,6 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByRolesContaining(RoleType roleType);
+
     Optional<User> getUserByUsername(String username);
 
     Optional<User> getUserByEmail(String email);

--- a/src/main/java/com/eukon05/financetracker/user/exception/AdminUserAlreadyExistsException.java
+++ b/src/main/java/com/eukon05/financetracker/user/exception/AdminUserAlreadyExistsException.java
@@ -1,0 +1,14 @@
+package com.eukon05.financetracker.user.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class AdminUserAlreadyExistsException extends ResponseStatusException {
+
+    private static final String MESSAGE_ADMIN_ALREADY_EXISTS = "The admin user has already been created";
+
+    public AdminUserAlreadyExistsException() {
+        super(HttpStatus.CONFLICT, MESSAGE_ADMIN_ALREADY_EXISTS);
+    }
+
+}

--- a/src/main/java/com/eukon05/financetracker/user/usecase/CreateUserUseCase.java
+++ b/src/main/java/com/eukon05/financetracker/user/usecase/CreateUserUseCase.java
@@ -1,7 +1,10 @@
 package com.eukon05.financetracker.user.usecase;
 
+import com.eukon05.financetracker.user.User;
 import com.eukon05.financetracker.user.dto.RegisterDTO;
 
 interface CreateUserUseCase {
-    void createUser(RegisterDTO dto, String rootUrl);
+    User createUser(RegisterDTO dto, String rootUrl);
+
+    void createAdminUser(String masterPassword, RegisterDTO dto, String rootUrl);
 }

--- a/src/main/java/com/eukon05/financetracker/user/usecase/UserFacade.java
+++ b/src/main/java/com/eukon05/financetracker/user/usecase/UserFacade.java
@@ -12,7 +12,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class UserFacade {
-
     private final CreateUserUseCase createUserUseCase;
     private final GetUserUseCase getUserUseCase;
     private final UpdateUserEmailUseCase updateUserEmailUseCase;
@@ -48,5 +47,8 @@ public class UserFacade {
         deleteMultipleUsersUseCase.deleteMultipleUsers(users);
     }
 
+    public void createAdmin(String masterPassword, RegisterDTO dto, String rootUrl) {
+        createUserUseCase.createAdminUser(masterPassword, dto, rootUrl);
+    }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,5 @@ server:
 springdoc:
   api-docs:
     path: /api-docs
+
+masterPassword: thisisamasterpass


### PR DESCRIPTION
Application administrator can now create an elevated permissions account for themselves.  
This type of account is only used for modifying the list of transaction categories as of now, but it's functionality may be extended in the future.  
To create an admin account, one must know the secret passphrase, located in the `application.yml` file under the name `masterPassword`.  
There can be only one admin user.