### PR TITLE
Fixed issues related to editing wallets

### DIFF
--- a/src/main/java/com/eukon05/financetracker/wallet/CurrencyConverterImpl.java
+++ b/src/main/java/com/eukon05/financetracker/wallet/CurrencyConverterImpl.java
@@ -27,23 +27,25 @@ public class CurrencyConverterImpl implements CurrencyConverter {
     @Override
     public BigDecimal convert(String from, String to, BigDecimal amount, Instant date) {
         try {
-            LocalDate parsedDate = LocalDate.ofInstant(date, ZoneId.systemDefault());
-            HttpResponse<String> response = getRequest(String.format(CONVERTER_API_URL, from, to, amount, parsedDate));
+            LocalDate parsedDate = LocalDate.ofInstant(date, ZoneId.of("UTC"));
+            JsonNode node = getRequest(String.format(CONVERTER_API_URL, from, to, amount.abs(), parsedDate));
+            BigDecimal result = new BigDecimal(node.get("result").asText());
 
-            JsonNode node = objectMapper.readValue(response.body(), JsonNode.class);
-            return new BigDecimal(node.get("result").asText());
+            return amount.signum() < 0 ? result.negate() : result;
+
         } catch (Exception ex) {
             ex.printStackTrace();
             throw new CurrencyConversionException();
         }
     }
 
-    private HttpResponse<String> getRequest(String url) throws IOException, InterruptedException {
+    private JsonNode getRequest(String url) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest
                 .newBuilder(URI.create(url))
                 .GET()
                 .build();
-        return client.send(request, HttpResponse.BodyHandlers.ofString());
+        String body = client.send(request, HttpResponse.BodyHandlers.ofString()).body();
+        return objectMapper.readValue(body, JsonNode.class);
     }
 
 }

--- a/src/main/java/com/eukon05/financetracker/wallet/WalletServiceImpl.java
+++ b/src/main/java/com/eukon05/financetracker/wallet/WalletServiceImpl.java
@@ -6,6 +6,7 @@ import com.eukon05.financetracker.wallet.dto.EditWalletDTO;
 import com.eukon05.financetracker.wallet.dto.WalletDTO;
 import com.eukon05.financetracker.wallet.exception.WalletNameTakenException;
 import com.eukon05.financetracker.wallet.exception.WalletNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -32,6 +33,7 @@ public class WalletServiceImpl implements WalletService {
         repository.delete(wallet);
     }
 
+    @Transactional
     public void editWallet(String userId, long walletID, EditWalletDTO dto) {
         Wallet wallet = getWalletById(userId, walletID);
 


### PR DESCRIPTION
Wallets weren't saved properly and the currency convertion API was throwing an error when a transaction creation date had an offset from the UTC time zone.
The API also had trouble dealing with negative values, so now the app sends a request with an absolute value of the transaction and then assigns a sign to the conversion result.

All of these issues are fixed in this PR.